### PR TITLE
Update revealjs.scss

### DIFF
--- a/_extensions/unhcr/revealjs.scss
+++ b/_extensions/unhcr/revealjs.scss
@@ -38,6 +38,7 @@ $border-radius: 0 !default;
 // headings
 $presentation-heading-color: $unhcr-blue !default;
 $presentation-h1-font-size: 2.2em !default;
+$presentation-h2-font-size: 1.25em !default;
 
 /*-- scss:rules --*/
 


### PR DESCRIPTION
**Change:** add h2 font size default to 1.25em in revealjs.scss

**Rationale:** writing action headers on slides require about 7 to 10 words minimum. When I use the UNHCR RevealJS template, the headers become too large, and take up more than a third of the frame. For this reason, I fixed the font size of frame titles to 1.25em which works much better in my testing.

- Masud.